### PR TITLE
Task#88982

### DIFF
--- a/stock_split_picking/model/stock.py
+++ b/stock_split_picking/model/stock.py
@@ -82,8 +82,11 @@ class StockMove(models.Model):
         else:
             moves.action_confirm()
         if move.procurement_id:
-            defaults = {'product_qty': qty,
-                        'state': 'running'}
+            defaults = {
+                'product_qty': qty,
+                'state': 'running',
+                'move_ids': [(6, 0, new_move.ids)],
+            }
             new_procurement = move.procurement_id.copy(default=defaults)
             new_move.procurement_id = new_procurement
             move.procurement_id.product_qty = move.product_qty


### PR DESCRIPTION
[FIX] stock_split_picking: Duplicated procurement must have move_ids setted on defaults, otherwise it creates the procurement as done.
